### PR TITLE
fix astro.config.mjs file

### DIFF
--- a/technolgap/astro.config.mjs
+++ b/technolgap/astro.config.mjs
@@ -3,5 +3,5 @@ import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({
-
+    output: 'server',
 });


### PR DESCRIPTION
that was preventing url.searchParams from working in the our-team page

added `output: 'server'`
